### PR TITLE
Add CI variable to only build on tagged commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: type IN (tag)
+
 language: cpp
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 # shallow clone
 clone_depth: 10
 
+skip_non_tags: true
+
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml


### PR DESCRIPTION
This will avoid duplicate build log from occuring between build on push commit vs tagged build in AppVeyor/Travis CI buildbot.

Example of the issue for AppVeyor shown as picture below:
![duplicate build](https://user-images.githubusercontent.com/18496868/33587725-608f4bd4-d9aa-11e7-89b8-7f2a38abbcd3.png)
